### PR TITLE
Encode fixes and improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/galdor/go-thumbhash
 go 1.20
 
 require github.com/galdor/go-program v0.0.0-20230403162644-22adfbe9fbab
+
+require golang.org/x/image v0.14.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.20
 
 require github.com/galdor/go-program v0.0.0-20230403162644-22adfbe9fbab
 
-require golang.org/x/image v0.14.0 // indirect
+require golang.org/x/image v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -3,4 +3,6 @@ github.com/galdor/go-program v0.0.0-20230403162644-22adfbe9fbab h1:czJoR/JfIjVSC
 github.com/galdor/go-program v0.0.0-20230403162644-22adfbe9fbab/go.mod h1:KnVdVzlic6wXk1wARM0MRJ2xviiZKgNA02bBjb8yTtc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+golang.org/x/image v0.14.0 h1:tNgSxAFe3jC4uYqvZdTr84SZoM1KfwdC9SKIFrLjFn4=
+golang.org/x/image v0.14.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/thumbhash_test.go
+++ b/thumbhash_test.go
@@ -33,4 +33,5 @@ func TestEncodeImage(t *testing.T) {
 
 	checkImage("1QcSHQRnh493V4dIh4eXh1h4kJUI", "data/sunrise.jpg")
 	checkImage("X5qGNQw7oElslqhGWfSE+Q6oJ1h2iHB2Rw==", "data/firefox.png")
+	checkImage("VvYRNQRod313B4h3eHhYiHeAiQUo", "data/large-sunrise.png")
 }


### PR DESCRIPTION
This PR does the following:
* Fixes a bug handling encoding images whose bounds don't start at the origin
* Resizes large images before the encoding process
* Re-uses allocated memory for the temporary RGBA image, LPQA and other encoding buffers
* Adds the large image to the test suite.
  - its hash was calculated before adding the resize logic, showing that it didn't change