### PR TITLE
upgrade go to v1.21, enable image data piping

### DIFF
--- a/cmd/thumbhash/main.go
+++ b/cmd/thumbhash/main.go
@@ -14,8 +14,11 @@ import (
 	"github.com/galdor/go-thumbhash"
 
 	"image/draw"
+	_ "image/gif"
 	_ "image/jpeg"
 	"image/png"
+
+	_ "golang.org/x/image/webp"
 )
 
 func main() {
@@ -29,7 +32,7 @@ func main() {
 	c.AddArgument("path", "the path of the image to decode")
 	c.AddOption("o", "output", "path", "", "the path to write decoded data to")
 
-	c = p.AddCommand("encode-image", "compute the hash of an image file",
+	c = p.AddCommand("encode-image", "compute the base64-encoded hash of an image file",
 		cmdEncodeImage)
 	c.AddArgument("path", "the path of the image to encode")
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/galdor/go-thumbhash
 
-go 1.20
+go 1.21
 
-require github.com/galdor/go-program v0.0.0-20230403162644-22adfbe9fbab
-
-require golang.org/x/image v0.14.0
+require (
+	github.com/galdor/go-program v0.0.0-20230403162644-22adfbe9fbab
+	golang.org/x/image v0.15.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,12 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/galdor/go-program v0.0.0-20230403162644-22adfbe9fbab h1:czJoR/JfIjVSCadg2h9Br4AmcdWfwfbgeArAJKTdWMY=
 github.com/galdor/go-program v0.0.0-20230403162644-22adfbe9fbab/go.mod h1:KnVdVzlic6wXk1wARM0MRJ2xviiZKgNA02bBjb8yTtc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-golang.org/x/image v0.14.0 h1:tNgSxAFe3jC4uYqvZdTr84SZoM1KfwdC9SKIFrLjFn4=
-golang.org/x/image v0.14.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/image v0.15.0 h1:kOELfmgrmJlw4Cdb7g/QGuB3CvDrXbqEIww/pNtNBm8=
+golang.org/x/image v0.15.0/go.mod h1:HUYqC05R2ZcZ3ejNQsIHQDQiwWM4JBqmm6MKANTp4LE=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/thumbhash.go
+++ b/thumbhash.go
@@ -66,7 +66,7 @@ func EncodeImage(img image.Image) []byte {
 
 	// resize images larger than max encoding dimension
 	// (no point in encoding large images)
-	if maxDim := imax(w, h); maxDim > maxEncodeDim {
+	if maxDim := max(w, h); maxDim > maxEncodeDim {
 		var scaleFactor float64
 		if w > h {
 			scaleFactor = maxEncodeDim / float64(w)
@@ -95,7 +95,7 @@ func EncodeImage(img image.Image) []byte {
 		}
 	}
 
-	if avgA > 0.0 {
+	if avgA != 0.0 {
 		avgR /= avgA
 		avgG /= avgA
 		avgB /= avgA
@@ -117,10 +117,10 @@ func EncodeImage(img image.Image) []byte {
 
 	wf := float64(w)
 	hf := float64(h)
-	maxWH := math.Max(wf, hf)
+	maxWH := max(wf, hf)
 
-	lx := imax(1, iround((lLimit*wf)/maxWH))
-	ly := imax(1, iround((lLimit*hf)/maxWH))
+	lx := max(1, iround((lLimit*wf)/maxWH))
+	ly := max(1, iround((lLimit*hf)/maxWH))
 
 	pixNum := 0
 	for y := 0; y < h; y++ {
@@ -165,16 +165,16 @@ func EncodeImage(img image.Image) []byte {
 
 				f /= float64(nbPixels)
 
-				if cx > 0 || cy > 0 {
+				if cx != 0 || cy != 0 {
 					ac = append(ac, f)
-					scale = math.Max(scale, math.Abs(f))
+					scale = max(scale, math.Abs(f))
 				} else {
 					dc = f
 				}
 			}
 		}
 
-		if scale > 0.0 {
+		if scale != 0.0 {
 			for i := 0; i < len(ac); i++ {
 				ac[i] = 0.5 + 0.5/scale*ac[i]
 			}
@@ -183,7 +183,7 @@ func EncodeImage(img image.Image) []byte {
 		return
 	}
 
-	lDC, lAC, lScale := encodeChannel(lpqa.L, imax(lx, 3), imax(ly, 3))
+	lDC, lAC, lScale := encodeChannel(lpqa.L, max(lx, 3), max(ly, 3))
 	pDC, pAC, pScale := encodeChannel(lpqa.P, 3, 3)
 	qDC, qAC, qScale := encodeChannel(lpqa.Q, 3, 3)
 
@@ -317,11 +317,11 @@ func DecodeImageWithCfg(hashData []byte, cfg DecodingCfg) (image.Image, error) {
 			r := (3.0*l - b + q) / 2.0
 			g := r - q
 
-			af := math.Max(0.0, math.Min(1.0, a))
+			af := max(0.0, math.Min(1.0, a))
 
-			data[idx] = byte(math.Max(0.0, math.Min(1.0, r)*255.0*af))
-			data[idx+1] = byte(math.Max(0.0, math.Min(1.0, g)*255.0*af))
-			data[idx+2] = byte(math.Max(0.0, math.Min(1.0, b)*255.0*af))
+			data[idx] = byte(max(0.0, math.Min(1.0, r)*255.0*af))
+			data[idx+1] = byte(max(0.0, math.Min(1.0, g)*255.0*af))
+			data[idx+2] = byte(max(0.0, math.Min(1.0, b)*255.0*af))
 			data[idx+3] = byte(af * 255.0)
 
 			idx += 4
@@ -333,12 +333,4 @@ func DecodeImageWithCfg(hashData []byte, cfg DecodingCfg) (image.Image, error) {
 
 func iround(x float64) int {
 	return int(math.Round(x))
-}
-
-func imax(x, y int) int {
-	if x >= y {
-		return x
-	}
-
-	return y
 }


### PR DESCRIPTION
- upgrades go to v1.21 and eliminates the use of `imax` in favor of go's built-in `max` function
- imports gif and webp libraries to add support for those file types
- reworks `cmd/thumbhash/main.go` slightly to add support for piping image data directly to `thumbhash encode-image` for better interoperability